### PR TITLE
Add install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ List your recent PRs formatted for Slack. Copies rich text to clipboard — Cmd+
 
 ```bash
 # Open, ready-for-review PRs authored by you
-./scripts/gh-pr-to-slack.sh
+gh-pr-to-slack
 
 # All PRs (merged, closed, draft, etc.)
-./scripts/gh-pr-to-slack.sh --all
+gh-pr-to-slack --all
 
 # Specific PRs by number
-./scripts/gh-pr-to-slack.sh 12595 12593
+gh-pr-to-slack 12595 12593
 ```
 
 Each PR is prefixed with a status emoji:


### PR DESCRIPTION
## Summary
- Add `## Install` section with curl one-liner to download scripts from GitHub release tag into `~/bin`
- Include PATH setup instructions for both zsh and bash
- Update Usage examples to use the installed command name (`gh-pr-to-slack`) instead of `./scripts/gh-pr-to-slack.sh`

## Test plan
- [x] Verify curl command downloads the script correctly: `curl -fsSL https://raw.githubusercontent.com/jsheffie/gh-to-slack/0.1/scripts/gh-pr-to-slack.sh -o ~/bin/gh-pr-to-slack && chmod +x ~/bin/gh-pr-to-slack`
- [x] Verify `gh-pr-to-slack --help` works after install
- [x] Confirm README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)