### PR TITLE
feat: Move date to first position in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ macOS shell script that formats GitHub CLI (`gh`) output (PRs, issues, etc.) int
 2. Download the script and make executable:
 
    ```bash
-   curl -fsSL https://raw.githubusercontent.com/jsheffie/gh-to-slack/0.2/scripts/gh-to-slack-pasteboard.sh \
+   curl -fsSL https://raw.githubusercontent.com/jsheffie/gh-to-slack/0.3/scripts/gh-to-slack-pasteboard.sh \
      -o ~/bin/gh-to-slack-pasteboard && chmod +x ~/bin/gh-to-slack-pasteboard
    ```
 
@@ -55,7 +55,7 @@ Terminal output uses ANSI-colored status icons for quick visual scanning. The `#
 
 ### PR Status Emoji (Slack)
 
-Each PR is prefixed with a status emoji in the clipboard output:
+Each line is formatted as: `date emoji title #number`. PRs use these status emoji:
 
 | Emoji | State |
 |---|---|
@@ -68,7 +68,7 @@ Each PR is prefixed with a status emoji in the clipboard output:
 
 ### Issue Status Emoji (Slack)
 
-Each issue is prefixed with a status emoji in the clipboard output:
+Issues use these status emoji:
 
 | Emoji | State |
 |---|---|

--- a/scripts/gh-to-slack-pasteboard.sh
+++ b/scripts/gh-to-slack-pasteboard.sh
@@ -165,18 +165,17 @@ fi
 
 JQ_TIMESTAMP='
   (.updatedAt | sub("\\.[0-9]+Z$"; "Z") | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime | . - 21600 | strftime("%b %d %I:%M%p")
-    | sub("^(?<pre>.* )0"; "\(.pre)")
     | sub("(?<h>[0-9]+:[0-9]+)(?<p>AM|PM)"; "\(.h)\(.p | ascii_downcase)")
   ) as $updated'
 
 # HTML with <a> links + Slack emoji (for clipboard rich text)
-html=$(echo "$json" | jq -r "[.[] | ${JQ_SLACK_EMOJI} | ${JQ_TIMESTAMP} | \"\(\$emoji) \(.title) <a href=\\\"\(.url)\\\">#\(.number)</a>  \(\$updated)\"] | join(\"<br>\")")
+html=$(echo "$json" | jq -r "[.[] | ${JQ_SLACK_EMOJI} | ${JQ_TIMESTAMP} | \"\(\$updated) \(\$emoji) \(.title) <a href=\\\"\(.url)\\\">#\(.number)</a>\"] | join(\"<br>\")")
 
 # Plain text with Slack emoji (clipboard fallback)
-slack_plain=$(echo "$json" | jq -r ".[] | ${JQ_SLACK_EMOJI} | ${JQ_TIMESTAMP} | \"\(\$emoji) \(.title) #\(.number)  \(\$updated)\"")
+slack_plain=$(echo "$json" | jq -r ".[] | ${JQ_SLACK_EMOJI} | ${JQ_TIMESTAMP} | \"\(\$updated) \(\$emoji) \(.title) #\(.number)\"")
 
 # Terminal output with ANSI colored icons and OSC 8 clickable links
-terminal_plain=$(echo "$json" | jq -r ".[] | ${JQ_TERMINAL_ICON} | ${JQ_TIMESTAMP} | \"\(\$icon) \(.title) \u001b]8;;\(.url)\u001b\\\\#\(.number)\u001b]8;;\u001b\\\\  \(\$updated)\"")
+terminal_plain=$(echo "$json" | jq -r ".[] | ${JQ_TERMINAL_ICON} | ${JQ_TIMESTAMP} | \"\(\$updated) \(\$icon) \(.title) \u001b]8;;\(.url)\u001b\\\\#\(.number)\u001b]8;;\u001b\\\\\"")
 
 # ── Clipboard ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Moves the date to appear first (before the emoji) in terminal, clipboard HTML, and plain text output
- Zero-pads single-digit days (e.g., `Mar 03` instead of `Mar 3`)
- Updates README install URL to point at release 0.3

Closes #15

## Test plan
- [ ] Run `gh-to-slack-pasteboard pr` and verify date appears first
- [ ] Run `gh-to-slack-pasteboard issue` and verify date appears first
- [ ] Paste into Slack and confirm formatting looks correct
- [ ] Verify single-digit days are zero-padded

🤖 Generated with [Claude Code](https://claude.com/claude-code)