### PR TITLE
fix: Wrap Slack date in backticks for alignment; bump to 0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ macOS shell script that formats GitHub CLI (`gh`) output (PRs, issues, etc.) int
 2. Download the script and make executable:
 
    ```bash
-   curl -fsSL https://raw.githubusercontent.com/jsheffie/gh-to-slack/0.3/scripts/gh-to-slack-pasteboard.sh \
+   curl -fsSL https://raw.githubusercontent.com/jsheffie/gh-to-slack/0.4/scripts/gh-to-slack-pasteboard.sh \
      -o ~/bin/gh-to-slack-pasteboard && chmod +x ~/bin/gh-to-slack-pasteboard
    ```
 

--- a/scripts/gh-to-slack-pasteboard.sh
+++ b/scripts/gh-to-slack-pasteboard.sh
@@ -172,7 +172,7 @@ JQ_TIMESTAMP='
 html=$(echo "$json" | jq -r "[.[] | ${JQ_SLACK_EMOJI} | ${JQ_TIMESTAMP} | \"\(\$updated) \(\$emoji) \(.title) <a href=\\\"\(.url)\\\">#\(.number)</a>\"] | join(\"<br>\")")
 
 # Plain text with Slack emoji (clipboard fallback)
-slack_plain=$(echo "$json" | jq -r ".[] | ${JQ_SLACK_EMOJI} | ${JQ_TIMESTAMP} | \"\(\$updated) \(\$emoji) \(.title) #\(.number)\"")
+slack_plain=$(echo "$json" | jq -r ".[] | ${JQ_SLACK_EMOJI} | ${JQ_TIMESTAMP} | \"\`\(\$updated)\` \(\$emoji) \(.title) #\(.number)\"")
 
 # Terminal output with ANSI colored icons and OSC 8 clickable links
 terminal_plain=$(echo "$json" | jq -r ".[] | ${JQ_TERMINAL_ICON} | ${JQ_TIMESTAMP} | \"\(\$updated) \(\$icon) \(.title) \u001b]8;;\(.url)\u001b\\\\#\(.number)\u001b]8;;\u001b\\\\\"")


### PR DESCRIPTION
## Summary
- Wraps the date field in backticks in the Slack plain text clipboard output so dates render monospaced, keeping emoji and text aligned across rows
- Bumps the install URL in README from `0.3` to `0.4`

Fixes #17

## Test plan
- [x] Run `gh-to-slack-pasteboard pr` and paste into Slack — verify dates are monospaced and aligned, emoji still renders
- [x] Run `gh-to-slack-pasteboard pr` — verify terminal output is unchanged
- [x] Verify README install URL points to `0.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)