### PR TITLE
fix: Use <code> tags in HTML clipboard for Slack date alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ macOS shell script that formats GitHub CLI (`gh`) output (PRs, issues, etc.) int
 2. Download the script and make executable:
 
    ```bash
-   curl -fsSL https://raw.githubusercontent.com/jsheffie/gh-to-slack/0.4/scripts/gh-to-slack-pasteboard.sh \
+   curl -fsSL https://raw.githubusercontent.com/jsheffie/gh-to-slack/0.5/scripts/gh-to-slack-pasteboard.sh \
      -o ~/bin/gh-to-slack-pasteboard && chmod +x ~/bin/gh-to-slack-pasteboard
    ```
 

--- a/scripts/gh-to-slack-pasteboard.sh
+++ b/scripts/gh-to-slack-pasteboard.sh
@@ -169,7 +169,8 @@ JQ_TIMESTAMP='
   ) as $updated'
 
 # HTML with <a> links + Slack emoji (for clipboard rich text)
-html=$(echo "$json" | jq -r "[.[] | ${JQ_SLACK_EMOJI} | ${JQ_TIMESTAMP} | \"\(\$updated) \(\$emoji) \(.title) <a href=\\\"\(.url)\\\">#\(.number)</a>\"] | join(\"<br>\")")
+# <code>\($updated)</code> \($emoji)
+html=$(echo "$json" | jq -r "[.[] | ${JQ_SLACK_EMOJI} | ${JQ_TIMESTAMP} | \"<code>\(\$updated)</code> \(\$emoji) \(.title) <a href=\\\"\(.url)\\\">#\(.number)</a>\"] | join(\"<br>\")")
 
 # Plain text with Slack emoji (clipboard fallback)
 slack_plain=$(echo "$json" | jq -r ".[] | ${JQ_SLACK_EMOJI} | ${JQ_TIMESTAMP} | \"\`\(\$updated)\` \(\$emoji) \(.title) #\(.number)\"")


### PR DESCRIPTION
## Summary
- PR #18 added backticks to the **plain text** clipboard, but Slack uses the **HTML** clipboard type when pasting — so dates were still misaligned
- Wraps the date in `<code>` tags in the HTML output so Slack renders dates as monospace inline code, keeping emoji and text aligned across rows
- Bumps install URL from `0.4` to `0.5`

Fixes #17

## Test plan
- [x] Run `gh-to-slack-pasteboard issue` and paste into Slack — dates render monospace with background, all rows aligned
- [x] Run `gh-to-slack-pasteboard pr` and paste into Slack — same alignment
- [x] Verify clickable links still work in Slack

🤖 Generated with [Claude Code](https://claude.com/claude-code)