### PR TITLE
fix: sort output by updatedAt descending

### DIFF
--- a/scripts/gh-to-slack-pasteboard.sh
+++ b/scripts/gh-to-slack-pasteboard.sh
@@ -170,13 +170,13 @@ JQ_TIMESTAMP='
 
 # HTML with <a> links + Slack emoji (for clipboard rich text)
 # <code>\($updated)</code> \($emoji)
-html=$(echo "$json" | jq -r "[.[] | ${JQ_SLACK_EMOJI} | ${JQ_TIMESTAMP} | \"<code>\(\$updated)</code> \(\$emoji) \(.title) <a href=\\\"\(.url)\\\">#\(.number)</a>\"] | join(\"<br>\")")
+html=$(echo "$json" | jq -r "[sort_by(.updatedAt) | reverse | .[] | ${JQ_SLACK_EMOJI} | ${JQ_TIMESTAMP} | \"<code>\(\$updated)</code> \(\$emoji) \(.title) <a href=\\\"\(.url)\\\">#\(.number)</a>\"] | join(\"<br>\")")
 
 # Plain text with Slack emoji (clipboard fallback)
-slack_plain=$(echo "$json" | jq -r ".[] | ${JQ_SLACK_EMOJI} | ${JQ_TIMESTAMP} | \"\`\(\$updated)\` \(\$emoji) \(.title) #\(.number)\"")
+slack_plain=$(echo "$json" | jq -r "sort_by(.updatedAt) | reverse | .[] | ${JQ_SLACK_EMOJI} | ${JQ_TIMESTAMP} | \"\`\(\$updated)\` \(\$emoji) \(.title) #\(.number)\"")
 
 # Terminal output with ANSI colored icons and OSC 8 clickable links
-terminal_plain=$(echo "$json" | jq -r ".[] | ${JQ_TERMINAL_ICON} | ${JQ_TIMESTAMP} | \"\(\$updated) \(\$icon) \(.title) \u001b]8;;\(.url)\u001b\\\\#\(.number)\u001b]8;;\u001b\\\\\"")
+terminal_plain=$(echo "$json" | jq -r "sort_by(.updatedAt) | reverse | .[] | ${JQ_TERMINAL_ICON} | ${JQ_TIMESTAMP} | \"\(\$updated) \(\$icon) \(.title) \u001b]8;;\(.url)\u001b\\\\#\(.number)\u001b]8;;\u001b\\\\\"")
 
 # ── Clipboard ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Add `sort_by(.updatedAt) | reverse` to all three jq pipelines (HTML, plain text, terminal) so output is always sorted newest-first
- Previously relied on `gh` CLI's default ordering (by PR/issue number), which didn't match the displayed `updatedAt` timestamps

Closes #20

## Test Plan
- [ ] Run `./scripts/gh-to-slack-pasteboard.sh pr --all` and verify dates appear in descending order
- [ ] Run `./scripts/gh-to-slack-pasteboard.sh issue` and verify same
- [ ] Paste into Slack and confirm ordering is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)