### PR TITLE
docs: add Homebrew as preferred install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ macOS shell script that formats GitHub CLI (`gh`) output (PRs, issues, etc.) int
 
 ## Install
 
+### Homebrew (recommended)
+
+```bash
+brew install jsheffie/homebrew-tap/gh-to-slack
+```
+
+### Manual
+
 1. Create `~/bin` if it doesn't exist:
 
    ```bash


### PR DESCRIPTION
## Summary
- Add `brew install jsheffie/homebrew-tap/gh-to-slack` as the recommended install method in the README
- Move existing manual install steps under a "Manual" subheading

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify `brew install jsheffie/homebrew-tap/gh-to-slack` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)