### PR TITLE
fix: correct Homebrew tap path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ macOS shell script that formats GitHub CLI (`gh`) output (PRs, issues, etc.) int
 ### Homebrew (recommended)
 
 ```bash
-brew install jsheffie/homebrew-tap/gh-to-slack
+brew install jsheffie/tap/gh-to-slack
 ```
 
 ### Manual


### PR DESCRIPTION
## Summary
- Fix `brew install` command from `jsheffie/homebrew-tap/gh-to-slack` to `jsheffie/tap/gh-to-slack`

## Test plan
- [ ] Verify `brew install jsheffie/tap/gh-to-slack` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)