### PR TITLE
feat: add --version flag (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ brew install jsheffie/tap/gh-to-slack
 2. Download the script and make executable:
 
    ```bash
-   curl -fsSL https://raw.githubusercontent.com/jsheffie/gh-to-slack/0.8/scripts/gh-to-slack-pasteboard.sh \
+   curl -fsSL https://raw.githubusercontent.com/jsheffie/gh-to-slack/v1.0.1/scripts/gh-to-slack-pasteboard.sh \
      -o ~/bin/gh-to-slack-pasteboard && chmod +x ~/bin/gh-to-slack-pasteboard
    ```
 

--- a/scripts/gh-to-slack-pasteboard.sh
+++ b/scripts/gh-to-slack-pasteboard.sh
@@ -3,6 +3,9 @@
 
 set -euo pipefail
 
+VERSION="1.0.1"
+RELEASES_URL="https://github.com/jsheffie/gh-to-slack/releases"
+
 usage() {
   cat <<EOF
 Usage: $(basename "$0") <pr|issue|activity|users> [OPTIONS] [NUMBER ...]
@@ -21,6 +24,7 @@ Options:
   --limit N   Max items per user (default: 10).
   --all       Show all items regardless of state (open, closed, merged, etc.)
               Default shows only open items.
+  --version   Show version and exit.
   -h, --help  Show this help message and exit.
 
 Arguments:
@@ -71,6 +75,11 @@ case "$subcommand" in
     ;;
   -h|--help)
     usage
+    ;;
+  --version)
+    echo "gh-to-slack-pasteboard ${VERSION}"
+    echo "${RELEASES_URL}"
+    exit 0
     ;;
   *)
     echo "Error: unknown subcommand '$subcommand'." >&2


### PR DESCRIPTION
## Summary
- Adds `--version` flag that prints version number and link to GitHub releases
- Hardcodes `VERSION="1.0.1"` at top of script for simplicity across install methods
- Updates manual install URL in README from `0.8` to `v1.0.1`

Closes #29

## Test plan
- [ ] `gh-to-slack-pasteboard --version` prints version and releases URL
- [ ] `gh-to-slack-pasteboard --help` shows `--version` in options

🤖 Generated with [Claude Code](https://claude.com/claude-code)