### PR TITLE
feat: add gh-create-syms.sh script for branch-named symlinks

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -8,12 +8,22 @@ macOS shell scripts that format GitHub CLI (`gh`) output (PRs, issues, etc.) int
 
 ## Architecture
 
-Scripts live in `scripts/`. The unified script `gh-to-slack-pasteboard.sh` is a Bash script that:
+Scripts live in `scripts/`:
+
+**`gh-to-slack-pasteboard.sh`** — formats GitHub PRs/issues as rich text for Slack:
 1. Calls `gh` CLI to fetch JSON data
 2. Uses `jq` to transform JSON into HTML (with `<a>` links) and plain text
 3. Uses an inline Swift snippet (`swift -e`) with `AppKit`/`NSPasteboard` to copy both `public.html` and plain string types to the macOS clipboard — Slack preserves hyperlinks from the HTML pasteboard type
 
+**`gh-create-syms.sh`** — creates branch-named symlinks for git repo directories:
+1. Finds real directories in CWD matching a given prefix (e.g. `django`, `django2`, `django3`)
+2. Reads each directory's current git branch
+3. Removes old symlinks targeting those directories (matched by `readlink` target)
+4. Creates symlinks of the form `<dirname>-<branch>` → `<dirname>`
+
 ## Running
+
+### gh-to-slack-pasteboard.sh
 
 ```bash
 # Open, ready-for-review PRs authored by you
@@ -35,18 +45,45 @@ Scripts live in `scripts/`. The unified script `gh-to-slack-pasteboard.sh` is a 
 ./scripts/gh-to-slack-pasteboard.sh issue 42 57
 ```
 
+### gh-create-syms.sh
+
+```bash
+# Create/refresh symlinks for all django* directories
+./scripts/gh-create-syms.sh django
+
+# List existing symlinks
+./scripts/gh-create-syms.sh django list
+
+# Remove all symlinks for django* directories
+./scripts/gh-create-syms.sh django clean
+
+# Only operate on django, django2, django3, … (skip django-old, etc.)
+./scripts/gh-create-syms.sh django --strict
+
+# Subcommands and --strict compose freely
+./scripts/gh-create-syms.sh django list --strict
+./scripts/gh-create-syms.sh django clean --strict
+```
+
 ## Dependencies
 
-- macOS (uses `NSPasteboard` via Swift)
-- `gh` CLI (authenticated)
-- `jq`
-- Swift runtime (ships with Xcode / Command Line Tools)
+- macOS (uses `NSPasteboard` via Swift) — required for `gh-to-slack-pasteboard.sh` only
+- `gh` CLI (authenticated) — required for `gh-to-slack-pasteboard.sh` only
+- `jq` — required for `gh-to-slack-pasteboard.sh` only
+- Swift runtime (ships with Xcode / Command Line Tools) — required for `gh-to-slack-pasteboard.sh` only
+- `git` — required for `gh-create-syms.sh`
 
 ## Conventions
 
 - Scripts use `set -euo pipefail`
 - PR state is mapped to custom Slack emoji (`:git--merged:`, `:git--approved:`, etc.) via jq
 - Timestamps are converted from UTC to CST (UTC-6 hardcoded offset) and formatted as `Mon DD H:MMam/pm`
+
+## Versioning
+
+All scripts share the same repo release version. When updating the `VERSION` variable in any script, update it in **all** scripts at the same time:
+- `scripts/gh-to-slack-pasteboard.sh`
+- `scripts/gh-create-syms.sh`
 
 ## GitHub CLI
 

--- a/scripts/gh-create-syms.sh
+++ b/scripts/gh-create-syms.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Create branch-named symlinks for git directories matching a prefix.
+# Usage: gh-create-syms <prefix> [create|list|clean] [--strict]
+
+set -euo pipefail
+
+VERSION="1.0.4"
+RELEASES_URL="https://github.com/jsheffie/gh-to-slack/releases"
+README_URL="https://github.com/jsheffie/gh-to-slack"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <prefix> [create|list|clean] [--strict]
+
+Create symlinks of the form <dirname>-<branch> for every real git directory
+in the current working directory whose name starts with <prefix>.
+
+Old symlinks pointing to those directories are removed first, so re-running
+after a branch switch keeps the workspace tidy.
+
+Subcommands:
+  create    Create/refresh symlinks (default when no subcommand given).
+  list      List existing symlinks for <prefix> without making changes.
+  clean     Remove all symlinks targeting <prefix>* directories.
+
+Options:
+  --strict    Only operate on directories named exactly <prefix> or
+              <prefix><N> where N is a positive integer
+              (e.g. django, django2, django3 — not django-old).
+  --version   Show version and exit.
+  -h, --help  Show this help message and exit.
+
+Examples:
+  $(basename "$0") django
+      Finds django/, django2/, django3/, … in CWD.
+      Creates: django-feature-auth -> django
+               django2-main        -> django2
+               django4-main        -> django4
+
+  $(basename "$0") django list
+      Lists existing symlinks, e.g.:
+        django   -> django-feature-auth
+        django2  -> django2-main
+
+  $(basename "$0") django clean
+      Removes all symlinks targeting django* directories.
+
+  $(basename "$0") django --strict
+      Only processes django, django2, django3, … (skips django-old, django_bak, etc.)
+
+  $(basename "$0") django list --strict
+      Lists only symlinks for strictly-numbered directories.
+
+  $(basename "$0") django clean --strict
+      Removes only symlinks for strictly-numbered directories.
+EOF
+  exit 0
+}
+
+if [ $# -eq 0 ]; then
+  echo "Error: prefix argument required." >&2
+  echo "Run '$(basename "$0") --help' for usage." >&2
+  exit 1
+fi
+
+case "$1" in
+  -h|--help) usage ;;
+  --version)
+    printf '\ngh-create-syms %s\n\n' "${VERSION}"
+    printf 'Check \033]8;;%s\033\\gh-to-slack releases\033]8;;\033\\. If you are not on the latest version\nsee \033]8;;%s\033\\README\033]8;;\033\\ for install upgrade instructions\n\n' "${RELEASES_URL}" "${README_URL}"
+    exit 0
+    ;;
+esac
+
+BASE="$1"
+shift
+
+SUBCMD="create"
+OPT_STRICT=0
+
+for arg in "$@"; do
+  case "$arg" in
+    create|list|clean) SUBCMD="$arg" ;;
+    --strict)          OPT_STRICT=1 ;;
+    -h|--help)         usage ;;
+    *) echo "Error: unknown argument '$arg'." >&2; exit 1 ;;
+  esac
+done
+
+# Returns 0 if dirname passes the active filter, 1 otherwise.
+dir_matches() {
+  local d="$1"
+  if [ "$OPT_STRICT" -eq 1 ]; then
+    # Accept exactly <BASE> or <BASE><digits>
+    [[ "$d" =~ ^${BASE}[0-9]*$ ]]
+  else
+    return 0
+  fi
+}
+
+# clean: remove all symlinks targeting <BASE>* directories
+if [ "$SUBCMD" = "clean" ]; then
+  found=0
+  while IFS= read -r -d '' sym; do
+    target=$(readlink "$sym")
+    if dir_matches "$target"; then
+      rm "$sym"
+      echo "Removed:  ${sym#./}"
+      found=1
+    fi
+  done < <(find . -maxdepth 1 -type l -print0)
+  [ "$found" -eq 0 ] && echo "No symlinks found to remove for prefix '${BASE}'."
+  exit 0
+fi
+
+# list: show existing symlinks targeting ${BASE}* dirs, no changes
+if [ "$SUBCMD" = "list" ]; then
+  # First pass: collect matches and find longest target name
+  declare -a list_syms list_targets
+  maxlen=0
+  while IFS= read -r -d '' sym; do
+    target=$(readlink "$sym")
+    if dir_matches "$target"; then
+      list_syms+=("${sym#./}")
+      list_targets+=("$target")
+      [ ${#target} -gt $maxlen ] && maxlen=${#target}
+    fi
+  done < <(find . -maxdepth 1 -type l -print0 | sort -z)
+
+  if [ ${#list_syms[@]} -eq 0 ]; then
+    echo "No symlinks found for prefix '${BASE}'."
+    exit 0
+  fi
+
+  # Second pass: print with padding = longest + 1
+  pad=$(( maxlen + 1 ))
+  for i in "${!list_syms[@]}"; do
+    printf "  %-${pad}s -> %s\n" "${list_targets[$i]}" "${list_syms[$i]}"
+  done
+  exit 0
+fi
+
+# create: create/refresh symlinks
+shopt -s nullglob
+dirs=()
+for entry in "${BASE}"*/; do
+  dir="${entry%/}"
+  [ -d "$dir" ] && [ ! -L "$dir" ] || continue
+  dir_matches "$dir" || continue
+  dirs+=("$dir")
+done
+shopt -u nullglob
+
+if [ ${#dirs[@]} -eq 0 ]; then
+  echo "No directories found matching '${BASE}*' in $(pwd)." >&2
+  exit 1
+fi
+
+for dirname in "${dirs[@]}"; do
+  # Verify it's a git repo
+  if ! git -C "$dirname" rev-parse HEAD >/dev/null 2>&1; then
+    echo "Warning: '$dirname' is not a git repo — skipping." >&2
+    continue
+  fi
+
+  # Get current branch; sanitize slashes → dashes
+  branch=$(git -C "$dirname" rev-parse --abbrev-ref HEAD | tr '/' '-')
+  symname="${dirname}-${branch}"
+
+  # Remove existing symlinks in CWD that target this directory
+  while IFS= read -r -d '' existing; do
+    target=$(readlink "$existing")
+    if [ "$target" = "$dirname" ]; then
+      rm "$existing"
+      echo "Removed:  ${existing#./}"
+    fi
+  done < <(find . -maxdepth 1 -type l -print0)
+
+  # Create new symlink
+  ln -s "$dirname" "$symname"
+  echo "Created:  $symname -> $dirname"
+done

--- a/scripts/gh-to-slack-pasteboard.sh
+++ b/scripts/gh-to-slack-pasteboard.sh
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-VERSION="1.0.3"
+VERSION="1.0.4"
 RELEASES_URL="https://github.com/jsheffie/gh-to-slack/releases"
 
 # ── Inline icon support ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds new `scripts/gh-create-syms.sh` script that creates branch-named symlinks for git repo directories matching a given prefix (e.g. `django-feature-auth -> django`)
- Supports `create` (default), `list`, and `clean` subcommands, plus a `--strict` flag to limit matches to `<prefix>` or `<prefix><N>` patterns
- Updates `CLAUDE.md` with architecture docs, usage examples, and dependency notes for the new script

## Test plan

- [ ] Run `./scripts/gh-create-syms.sh <prefix>` in a directory with multiple git repos sharing a prefix — verify symlinks are created as `<dirname>-<branch>`
- [ ] Re-run after switching branches — verify old symlinks are removed and new ones created
- [ ] Run `list` subcommand — verify output shows existing symlinks without making changes
- [ ] Run `clean` subcommand — verify all matching symlinks are removed
- [ ] Run with `--strict` flag — verify only `<prefix>` and `<prefix><N>` dirs are processed
- [ ] Run `--version` and `--help` — verify correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)