### PR TITLE
bump version to 1.0.5

### DIFF
--- a/scripts/gh-create-syms.sh
+++ b/scripts/gh-create-syms.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-VERSION="1.0.4"
+VERSION="1.0.5"
 RELEASES_URL="https://github.com/jsheffie/gh-to-slack/releases"
 README_URL="https://github.com/jsheffie/gh-to-slack"
 

--- a/scripts/gh-to-slack-pasteboard.sh
+++ b/scripts/gh-to-slack-pasteboard.sh
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-VERSION="1.0.4"
+VERSION="1.0.5"
 RELEASES_URL="https://github.com/jsheffie/gh-to-slack/releases"
 
 # ── Inline icon support ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Bumps `VERSION` to `1.0.5` in both `gh-to-slack-pasteboard.sh` and `gh-create-syms.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)