### PR TITLE
hide draft PRs by default (#44)

### DIFF
--- a/scripts/gh-create-syms.sh
+++ b/scripts/gh-create-syms.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-VERSION="1.0.5"
+VERSION="1.0.6"
 RELEASES_URL="https://github.com/jsheffie/gh-to-slack/releases"
 README_URL="https://github.com/jsheffie/gh-to-slack"
 

--- a/scripts/gh-to-slack-pasteboard.sh
+++ b/scripts/gh-to-slack-pasteboard.sh
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-VERSION="1.0.5"
+VERSION="1.0.6"
 RELEASES_URL="https://github.com/jsheffie/gh-to-slack/releases"
 
 # ── Inline icon support ──────────────────────────────────────────────
@@ -510,6 +510,9 @@ fetch_json() {
     json=$(gh "$gh_cmd" list "${gh_list_filter[@]}" --limit 100 --state all --json "$json_fields")
   else
     json=$(gh "$gh_cmd" list "${gh_list_filter[@]}" --limit "$limit" --state open --json "$json_fields")
+    if [ "$subcommand" = "pr" ]; then
+      json=$(echo "$json" | jq '[.[] | select(.isDraft | not)]')
+    fi
   fi
 }
 


### PR DESCRIPTION
## Summary
- Draft PRs are now excluded from the default `pr` output (`gh pr list --state open` includes drafts, so they were previously shown)
- Draft PRs still appear when using `--all`
- Explicit PR numbers (e.g. `pr 123`) are unaffected — drafts still show when requested directly
- Bumps version to 1.0.6

## Test plan
- [ ] Run `gh-to-slack-pasteboard pr` — confirm no draft PRs in output
- [ ] Run `gh-to-slack-pasteboard pr --all` — confirm draft PRs appear
- [ ] Run `gh-to-slack-pasteboard pr --version` — confirm version shows `1.0.6`

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)