### PR TITLE
rename scripts to gh-clippy and gh-syms

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -10,68 +10,70 @@ macOS shell scripts that format GitHub CLI (`gh`) output (PRs, issues, etc.) int
 
 Scripts live in `scripts/`:
 
-**`gh-to-slack-pasteboard.sh`** — formats GitHub PRs/issues as rich text for Slack:
+**`gh-clippy.sh`** — formats GitHub PRs/issues as rich text for Slack:
 1. Calls `gh` CLI to fetch JSON data
 2. Uses `jq` to transform JSON into HTML (with `<a>` links) and plain text
 3. Uses an inline Swift snippet (`swift -e`) with `AppKit`/`NSPasteboard` to copy both `public.html` and plain string types to the macOS clipboard — Slack preserves hyperlinks from the HTML pasteboard type
 
-**`gh-create-syms.sh`** — creates branch-named symlinks for git repo directories:
+**`gh-syms.sh`** — creates branch-named symlinks for git repo directories:
 1. Finds real directories in CWD matching a given prefix (e.g. `django`, `django2`, `django3`)
 2. Reads each directory's current git branch
 3. Removes old symlinks targeting those directories (matched by `readlink` target)
 4. Creates symlinks of the form `<dirname>-<branch>` → `<dirname>`
+5. Lists the current symlinks
+
+Default run (no subcommand) does all three phases: remove → create → list.
 
 ## Running
 
-### gh-to-slack-pasteboard.sh
+### gh-clippy.sh
 
 ```bash
 # Open, ready-for-review PRs authored by you
-./scripts/gh-to-slack-pasteboard.sh pr
+./scripts/gh-clippy.sh pr
 
 # All PRs (merged, closed, draft, etc.)
-./scripts/gh-to-slack-pasteboard.sh pr --all
+./scripts/gh-clippy.sh pr --all
 
 # Specific PRs by number
-./scripts/gh-to-slack-pasteboard.sh pr 12595 12593
+./scripts/gh-clippy.sh pr 12595 12593
 
 # Open issues assigned to you
-./scripts/gh-to-slack-pasteboard.sh issue
+./scripts/gh-clippy.sh issue
 
 # All issues (open + closed)
-./scripts/gh-to-slack-pasteboard.sh issue --all
+./scripts/gh-clippy.sh issue --all
 
 # Specific issues by number
-./scripts/gh-to-slack-pasteboard.sh issue 42 57
+./scripts/gh-clippy.sh issue 42 57
 ```
 
-### gh-create-syms.sh
+### gh-syms.sh
 
 ```bash
-# Create/refresh symlinks for all django* directories
-./scripts/gh-create-syms.sh django
+# Remove stale symlinks, create fresh ones, list (default)
+./scripts/gh-syms.sh django
 
-# List existing symlinks
-./scripts/gh-create-syms.sh django list
+# Same with verbose removal/creation output
+./scripts/gh-syms.sh django --verbose
+
+# List existing symlinks only
+./scripts/gh-syms.sh django list
 
 # Remove all symlinks for django* directories
-./scripts/gh-create-syms.sh django clean
+./scripts/gh-syms.sh django clean
 
-# Only operate on django, django2, django3, … (skip django-old, etc.)
-./scripts/gh-create-syms.sh django --strict
-
-# Subcommands and --strict compose freely
-./scripts/gh-create-syms.sh django list --strict
-./scripts/gh-create-syms.sh django clean --strict
+# Also process django-old, django_bak, etc. (default is strict: django, django2, django3 only)
+./scripts/gh-syms.sh django --no-strict-nums-only
 ```
 
 ## Dependencies
 
-- macOS (uses `NSPasteboard` via Swift) — required for `gh-to-slack-pasteboard.sh` only
-- `gh` CLI (authenticated) — required for `gh-to-slack-pasteboard.sh` only
-- `jq` — required for `gh-to-slack-pasteboard.sh` only
-- Swift runtime (ships with Xcode / Command Line Tools) — required for `gh-to-slack-pasteboard.sh` only
-- `git` — required for `gh-create-syms.sh`
+- macOS (uses `NSPasteboard` via Swift) — required for `gh-clippy.sh` only
+- `gh` CLI (authenticated) — required for `gh-clippy.sh` only
+- `jq` — required for `gh-clippy.sh` only
+- Swift runtime (ships with Xcode / Command Line Tools) — required for `gh-clippy.sh` only
+- `git` — required for `gh-syms.sh`
 
 ## Conventions
 
@@ -82,8 +84,8 @@ Scripts live in `scripts/`:
 ## Versioning
 
 All scripts share the same repo release version. When updating the `VERSION` variable in any script, update it in **all** scripts at the same time:
-- `scripts/gh-to-slack-pasteboard.sh`
-- `scripts/gh-create-syms.sh`
+- `scripts/gh-clippy.sh`
+- `scripts/gh-syms.sh`
 
 ## GitHub CLI
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # gh-to-slack
 
-macOS shell script that formats GitHub CLI (`gh`) output (PRs, issues, etc.) into rich text and copies it to the clipboard for pasting into Slack with clickable links and custom emoji.
+macOS shell scripts that format GitHub CLI (`gh`) output (PRs, issues, etc.) into rich text and copy it to the clipboard for pasting into Slack with clickable links and custom emoji.
+
+## Scripts
+
+- **`gh-clippy`** — formats GitHub PRs/issues as rich text for Slack
+- **`gh-syms`** — creates branch-named symlinks for git repo directories
 
 ## Install
 
@@ -18,11 +23,14 @@ brew install jsheffie/tap/gh-to-slack
    mkdir -p ~/bin
    ```
 
-2. Download the script and make executable:
+2. Download the scripts and make executable:
 
    ```bash
-   curl -fsSL https://raw.githubusercontent.com/jsheffie/gh-to-slack/v1.0.1/scripts/gh-to-slack-pasteboard.sh \
-     -o ~/bin/gh-to-slack-pasteboard && chmod +x ~/bin/gh-to-slack-pasteboard
+   curl -fsSL https://raw.githubusercontent.com/jsheffie/gh-to-slack/v1.0.7/scripts/gh-clippy.sh \
+     -o ~/bin/gh-clippy && chmod +x ~/bin/gh-clippy
+
+   curl -fsSL https://raw.githubusercontent.com/jsheffie/gh-to-slack/v1.0.7/scripts/gh-syms.sh \
+     -o ~/bin/gh-syms && chmod +x ~/bin/gh-syms
    ```
 
 3. Add `~/bin` to your PATH (if not already there):
@@ -39,37 +47,54 @@ brew install jsheffie/tap/gh-to-slack
 
 ## Dependencies
 
-- macOS (uses `NSPasteboard` via Swift for clipboard access)
-- [`gh`](https://cli.github.com/) CLI (authenticated)
-- [`jq`](https://jqlang.github.io/jq/)
-- Swift runtime (ships with Xcode / Command Line Tools)
+- macOS (uses `NSPasteboard` via Swift for clipboard access) — `gh-clippy` only
+- [`gh`](https://cli.github.com/) CLI (authenticated) — `gh-clippy` only
+- [`jq`](https://jqlang.github.io/jq/) — `gh-clippy` only
+- Swift runtime (ships with Xcode / Command Line Tools) — `gh-clippy` only
+- `git` — `gh-syms` only
 
 ## Usage
 
+### gh-clippy
+
 List your recent PRs or issues formatted for Slack. Copies rich text to clipboard — Cmd+V into Slack gives clickable links.
 
-**Indivual Developer Focused:**
-This usage efaults to `@me` usage for status reporting
+**Individual Developer Focused:**
+Defaults to `@me` for status reporting.
 ```bash
-gh-to-slack-pasteboard pr                    # Open, ready-for-review PRs
-gh-to-slack-pasteboard pr --all              # All PRs
-gh-to-slack-pasteboard pr 12595 12593        # Specific PRs
-gh-to-slack-pasteboard pr --limit 20              # Up to 20 PRs
-gh-to-slack-pasteboard issue                 # Open issues assigned to me
-gh-to-slack-pasteboard issue --all           # All issues
-gh-to-slack-pasteboard issue 42 57           # Specific issues
-gh-to-slack-pasteboard issue --limit 5       # Show 5 issue
+gh-clippy pr                    # Open, ready-for-review PRs
+gh-clippy pr --all              # All PRs
+gh-clippy pr 12595 12593        # Specific PRs
+gh-clippy pr --limit 20         # Up to 20 PRs
+gh-clippy issue                 # Open issues assigned to me
+gh-clippy issue --all           # All issues
+gh-clippy issue 42 57           # Specific issues
+gh-clippy issue --limit 5       # Show 5 issues
 ```
 
-**Team/Management Focused** 
+**Team/Management Focused:**
 
 ```bash
-gh-to-slack-pasteboard activity                   # Recent issues & PRs (defautlts to 10 each)
-gh-to-slack-pasteboard activity --user-display    # With linked usernames
-gh-to-slack-pasteboard activity --limit 5         # 5 items per section
-gh-to-slack-pasteboard pr --user octocat          # Open PRs by octocat
-gh-to-slack-pasteboard issue --user bob --user ben # Issues for multiple users
-gh-to-slack-pasteboard users                      # List collaborators with links
+gh-clippy activity                    # Recent issues & PRs (defaults to 10 each)
+gh-clippy activity --user-display     # With linked usernames
+gh-clippy activity --limit 5          # 5 items per section
+gh-clippy pr --user octocat           # Open PRs by octocat
+gh-clippy issue --user bob --user ben # Issues for multiple users
+gh-clippy users                       # List collaborators with links
+```
+
+### gh-syms
+
+Create branch-named symlinks for git directories in the current working directory. Running without a subcommand removes stale symlinks, creates fresh ones, then lists the result.
+
+By default only directories named exactly `<prefix>` or `<prefix><N>` (e.g. `django`, `django2`, `django3`) are processed — not `django-old` or `django_bak`.
+
+```bash
+gh-syms django                        # Remove stale, create fresh, list
+gh-syms django --verbose              # Same, with removal/creation details
+gh-syms django list                   # List existing symlinks only
+gh-syms django clean                  # Remove all symlinks for django* dirs
+gh-syms django --no-strict-nums-only  # Also process django-old, django_bak, etc.
 ```
 
 ### Terminal Output

--- a/scripts/gh-clippy.sh
+++ b/scripts/gh-clippy.sh
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-VERSION="1.0.6"
+VERSION="1.0.7"
 RELEASES_URL="https://github.com/jsheffie/gh-to-slack/releases"
 
 # ── Inline icon support ──────────────────────────────────────────────
@@ -136,7 +136,7 @@ case "$subcommand" in
     ;;
   --version)
     readme_url="https://github.com/jsheffie/gh-to-slack"
-    printf '\ngh-to-slack-pasteboard %s\n\n' "${VERSION}"
+    printf '\ngh-clippy %s\n\n' "${VERSION}"
     printf 'Check \033]8;;%s\033\\gh-to-slack releases\033]8;;\033\\. If you are not on the latest version\nsee \033]8;;%s\033\\README\033]8;;\033\\ for install upgrade instructions\n\n' "${RELEASES_URL}" "${readme_url}"
     exit 0
     ;;

--- a/scripts/gh-syms.sh
+++ b/scripts/gh-syms.sh
@@ -1,58 +1,53 @@
 #!/usr/bin/env bash
 # Create branch-named symlinks for git directories matching a prefix.
-# Usage: gh-create-syms <prefix> [create|list|clean] [--strict]
+# Usage: gh-syms <prefix> [create|list|clean] [--no-strict-nums-only] [--verbose]
 
 set -euo pipefail
 
-VERSION="1.0.6"
+VERSION="1.0.7"
 RELEASES_URL="https://github.com/jsheffie/gh-to-slack/releases"
 README_URL="https://github.com/jsheffie/gh-to-slack"
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") <prefix> [create|list|clean] [--strict]
+Usage: $(basename "$0") <prefix> [create|list|clean] [--no-strict-nums-only] [--verbose]
 
 Create symlinks of the form <dirname>-<branch> for every real git directory
 in the current working directory whose name starts with <prefix>.
 
-Old symlinks pointing to those directories are removed first, so re-running
-after a branch switch keeps the workspace tidy.
+By default only directories named exactly <prefix> or <prefix><N> (where N is
+a positive integer) are processed — e.g. django, django2, django3 but not
+django-old. Pass --no-strict-nums-only to process all <prefix>* directories.
 
 Subcommands:
-  create    Create/refresh symlinks (default when no subcommand given).
+  (none)    Remove stale symlinks, create fresh ones, then list. (default)
+  create    Create/refresh symlinks only (no listing).
   list      List existing symlinks for <prefix> without making changes.
   clean     Remove all symlinks targeting <prefix>* directories.
 
 Options:
-  --strict    Only operate on directories named exactly <prefix> or
-              <prefix><N> where N is a positive integer
-              (e.g. django, django2, django3 — not django-old).
-  --version   Show version and exit.
-  -h, --help  Show this help message and exit.
+  --no-strict-nums-only   Also process directories like django-old, django_bak.
+  --verbose               Print each removal and creation (default: list only).
+  --version               Show version and exit.
+  -h, --help              Show this help message and exit.
 
 Examples:
   $(basename "$0") django
-      Finds django/, django2/, django3/, … in CWD.
-      Creates: django-feature-auth -> django
-               django2-main        -> django2
-               django4-main        -> django4
-
-  $(basename "$0") django list
-      Lists existing symlinks, e.g.:
+      Removes stale symlinks, creates fresh ones, then lists:
         django   -> django-feature-auth
         django2  -> django2-main
+
+  $(basename "$0") django list
+      Lists existing symlinks without making changes.
 
   $(basename "$0") django clean
       Removes all symlinks targeting django* directories.
 
-  $(basename "$0") django --strict
-      Only processes django, django2, django3, … (skips django-old, django_bak, etc.)
+  $(basename "$0") django --no-strict-nums-only
+      Also processes django-old, django_bak, etc.
 
-  $(basename "$0") django list --strict
-      Lists only symlinks for strictly-numbered directories.
-
-  $(basename "$0") django clean --strict
-      Removes only symlinks for strictly-numbered directories.
+  $(basename "$0") django --verbose
+      Shows each removal and creation before the final list.
 EOF
   exit 0
 }
@@ -66,7 +61,7 @@ fi
 case "$1" in
   -h|--help) usage ;;
   --version)
-    printf '\ngh-create-syms %s\n\n' "${VERSION}"
+    printf '\ngh-syms %s\n\n' "${VERSION}"
     printf 'Check \033]8;;%s\033\\gh-to-slack releases\033]8;;\033\\. If you are not on the latest version\nsee \033]8;;%s\033\\README\033]8;;\033\\ for install upgrade instructions\n\n' "${RELEASES_URL}" "${README_URL}"
     exit 0
     ;;
@@ -75,14 +70,16 @@ esac
 BASE="$1"
 shift
 
-SUBCMD="create"
-OPT_STRICT=0
+SUBCMD="default"
+OPT_STRICT=1
+OPT_VERBOSE=0
 
 for arg in "$@"; do
   case "$arg" in
-    create|list|clean) SUBCMD="$arg" ;;
-    --strict)          OPT_STRICT=1 ;;
-    -h|--help)         usage ;;
+    create|list|clean)     SUBCMD="$arg" ;;
+    --no-strict-nums-only) OPT_STRICT=0 ;;
+    --verbose)             OPT_VERBOSE=1 ;;
+    -h|--help)             usage ;;
     *) echo "Error: unknown argument '$arg'." >&2; exit 1 ;;
   esac
 done
@@ -98,14 +95,14 @@ dir_matches() {
   fi
 }
 
-# clean: remove all symlinks targeting <BASE>* directories
+# ── clean subcommand ───────────────────────────────────────────────────
 if [ "$SUBCMD" = "clean" ]; then
   found=0
   while IFS= read -r -d '' sym; do
     target=$(readlink "$sym")
     if dir_matches "$target"; then
       rm "$sym"
-      echo "Removed:  ${sym#./}"
+      [ "$OPT_VERBOSE" -eq 1 ] && echo "Removed:  ${sym#./}"
       found=1
     fi
   done < <(find . -maxdepth 1 -type l -print0)
@@ -113,12 +110,12 @@ if [ "$SUBCMD" = "clean" ]; then
   exit 0
 fi
 
-# list: show existing symlinks targeting ${BASE}* dirs, no changes
-if [ "$SUBCMD" = "list" ]; then
-  # First pass: collect matches and find longest target name
+# ── list helper (used by list subcommand and default run) ──────────────
+do_list() {
   declare -a list_syms list_targets
-  maxlen=0
+  local maxlen=0
   while IFS= read -r -d '' sym; do
+    local target
     target=$(readlink "$sym")
     if dir_matches "$target"; then
       list_syms+=("${sym#./}")
@@ -129,18 +126,21 @@ if [ "$SUBCMD" = "list" ]; then
 
   if [ ${#list_syms[@]} -eq 0 ]; then
     echo "No symlinks found for prefix '${BASE}'."
-    exit 0
+    return
   fi
 
-  # Second pass: print with padding = longest + 1
-  pad=$(( maxlen + 1 ))
+  local pad=$(( maxlen + 1 ))
   for i in "${!list_syms[@]}"; do
     printf "  %-${pad}s -> %s\n" "${list_targets[$i]}" "${list_syms[$i]}"
   done
+}
+
+if [ "$SUBCMD" = "list" ]; then
+  do_list
   exit 0
 fi
 
-# create: create/refresh symlinks
+# ── create / default: collect matching real directories ────────────────
 shopt -s nullglob
 dirs=()
 for entry in "${BASE}"*/; do
@@ -172,11 +172,16 @@ for dirname in "${dirs[@]}"; do
     target=$(readlink "$existing")
     if [ "$target" = "$dirname" ]; then
       rm "$existing"
-      echo "Removed:  ${existing#./}"
+      [ "$OPT_VERBOSE" -eq 1 ] && echo "Removed:  ${existing#./}"
     fi
   done < <(find . -maxdepth 1 -type l -print0)
 
   # Create new symlink
   ln -s "$dirname" "$symname"
-  echo "Created:  $symname -> $dirname"
+  [ "$OPT_VERBOSE" -eq 1 ] && echo "Created:  $symname -> $dirname"
 done
+
+# Default run also prints the listing; bare `create` subcommand does not.
+if [ "$SUBCMD" = "default" ]; then
+  do_list
+fi


### PR DESCRIPTION
Closes #46

## Summary
- Renamed `gh-to-slack-pasteboard.sh` → `gh-clippy.sh` (installed as `gh-clippy`)
- Renamed `gh-create-syms.sh` → `gh-syms.sh` (installed as `gh-syms`)
- `gh-syms`: strict mode (numbers-only prefix matching) is now the default; `--strict` removed, `--no-strict-nums-only` added to opt out
- `gh-syms`: default run (no subcommand) now does remove → create → list in sequence
- `gh-syms`: added `--verbose` flag to show each removal/creation; final list always prints
- Updated README and CLAUDE.md
- Bumped version to 1.0.7

## Note
Homebrew formula in `jsheffie/homebrew-tap` will need a follow-up update to reference the new script names and binary names.

## Test plan
- [ ] `gh-clippy pr` copies formatted PR list to clipboard
- [ ] `gh-clippy --version` shows `gh-clippy 1.0.7`
- [ ] `gh-syms <prefix>` removes stale symlinks, creates fresh ones, lists result
- [ ] `gh-syms <prefix> --verbose` shows Removed/Created lines before listing
- [ ] `gh-syms <prefix> --no-strict-nums-only` processes hyphenated dirs (e.g. `django-old`)
- [ ] `gh-syms <prefix> list` lists only, no changes
- [ ] `gh-syms <prefix> clean` removes all, silent without `--verbose`
- [ ] `gh-syms --version` shows `gh-syms 1.0.7`