### PR TITLE
bump version to 1.0.8

### DIFF
--- a/scripts/gh-clippy.sh
+++ b/scripts/gh-clippy.sh
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-VERSION="1.0.7"
+VERSION="1.0.8"
 RELEASES_URL="https://github.com/jsheffie/gh-to-slack/releases"
 
 # ── Inline icon support ──────────────────────────────────────────────

--- a/scripts/gh-syms.sh
+++ b/scripts/gh-syms.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-VERSION="1.0.7"
+VERSION="1.0.8"
 RELEASES_URL="https://github.com/jsheffie/gh-to-slack/releases"
 README_URL="https://github.com/jsheffie/gh-to-slack"
 


### PR DESCRIPTION
Force a new release to fix tap versioning from the previous release.

## Summary
- Bump VERSION from 1.0.7 → 1.0.8 in `gh-clippy.sh` and `gh-syms.sh`